### PR TITLE
🧪 [testing improvement] Add missing DOM element error test in nodeFromTemplate

### DIFF
--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Utils: nodeFromTemplate', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('throws error when template is not found', async ({ page }) => {
+    const errorMessage = await page.evaluate(async () => {
+      const { nodeFromTemplate } = await import('/src/utils.ts');
+      try {
+        nodeFromTemplate('#non-existent-template');
+        return 'No error thrown';
+      } catch (e: any) {
+        return e.message;
+      }
+    });
+
+    expect(errorMessage).toBe('Template with id #non-existent-template not found');
+  });
+
+  test('returns DocumentFragment when template exists', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const { nodeFromTemplate } = await import('/src/utils.ts');
+
+      // Create a template element
+      const template = document.createElement('template');
+      template.id = 'test-template';
+      template.innerHTML = '<div class="test-content">Hello</div>';
+      document.body.appendChild(template);
+
+      try {
+        const node = nodeFromTemplate('#test-template');
+        return {
+          isDocumentFragment: node instanceof DocumentFragment,
+          content: node.querySelector('.test-content')?.textContent
+        };
+      } finally {
+        document.body.removeChild(template);
+      }
+    });
+
+    expect(result.isDocumentFragment).toBe(true);
+    expect(result.content).toBe('Hello');
+  });
+});


### PR DESCRIPTION
Added test coverage for `nodeFromTemplate` in `src/utils.ts`.

🎯 **What:** Addressed the testing gap for missing DOM element errors in the `nodeFromTemplate` utility.
📊 **Coverage:** 
- Error handling for missing templates.
- Successful node creation from valid templates.
✨ **Result:** Increased reliability of core utility functions by ensuring error paths are correctly handled and verified.

---
*PR created automatically by Jules for task [11683260098531840842](https://jules.google.com/task/11683260098531840842) started by @nop33*