### PR TITLE
Add explicit "Get Location" button to gymtime form

### DIFF
--- a/gymtime/index.html
+++ b/gymtime/index.html
@@ -50,12 +50,26 @@
           <form id="gymtime-form" class="flex flex-col gap-2">
             <input type="hidden" name="programId" value="" required />
             <input class="w-full p-2 rounded border border-neutral-600" type="date" name="date" value="" required />
-            <input
-              class="w-full p-2 rounded border border-neutral-600"
-              type="text"
-              name="location"
-              placeholder="Location"
-            />
+            <div class="flex gap-2 w-full">
+              <input
+                class="w-full p-2 rounded border border-neutral-600 flex-grow"
+                type="text"
+                name="location"
+                placeholder="Location"
+              />
+              <button
+                type="button"
+                id="get-location-btn"
+                class="btn-secondary px-3 shrink-0"
+                aria-label="Get current location"
+                title="Get current location"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1 1 15 0Z" />
+                </svg>
+              </button>
+            </div>
             <textarea class="w-full p-2 rounded border border-neutral-600" name="notes" placeholder="Notes"></textarea>
             <button type="submit" class="btn-primary text-white w-full">Save & start workout</button>
           </form>

--- a/src/pages/gymtime/WorkoutSessionForm.ts
+++ b/src/pages/gymtime/WorkoutSessionForm.ts
@@ -9,6 +9,7 @@ class WorkoutSessionForm {
   private static programIdInput = this.form.querySelector('input[name="programId"]') as HTMLInputElement
   private static dateInput = this.form.querySelector('input[name="date"]') as HTMLInputElement
   private static locationInput = this.form.querySelector('input[name="location"]') as HTMLInputElement
+  private static getLocationBtn = this.form.querySelector('#get-location-btn') as HTMLButtonElement
   private static notesInput = this.form.querySelector('textarea[name="notes"]') as HTMLTextAreaElement
   private static submitButton = this.form.querySelector('button[type="submit"]') as HTMLButtonElement
   private static programId: Program['id']
@@ -33,9 +34,11 @@ class WorkoutSessionForm {
 
     if (session) {
       this.locationInput.value = session.location
-    } else {
-      setCityFromGeolocation(this.locationInput)
     }
+
+    this.getLocationBtn.addEventListener('click', () => {
+      setCityFromGeolocation(this.locationInput)
+    })
 
     if (session?.status === 'completed') {
       this.submitButton.textContent = 'Save'


### PR DESCRIPTION
Fixes the issue where the browser asks for geolocation permission automatically every time a user visits the `/gymtime` page to log a workout.

Added an icon button next to the location input field. When the user clicks the button, the location is fetched. This prevents the browser from prompting for permission on page load, respecting the user's preference to manually fetch the location when desired.

---
*PR created automatically by Jules for task [16384818416659614406](https://jules.google.com/task/16384818416659614406) started by @nop33*