### PR TITLE
refactor: rename 'move up' and 'move down' button texts

### DIFF
--- a/gymtime/index.html
+++ b/gymtime/index.html
@@ -157,7 +157,7 @@
                     >
                       <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 15.75l7.5-7.5 7.5 7.5" />
                     </svg>
-                    move up
+                    up
                   </button>
                   <button
                     class="move-down-workout-session-exercise-btn hidden cursor-pointer flex items-center justify-center gap-2 rounded-lg border border-jim-accent/40 min-h-0 px-3 py-1.5 text-sm text-jim-accent/80 transition-colors duration-150 hover:border-jim-accent/60 hover:text-jim-accent active:bg-jim-accent/20"
@@ -172,7 +172,7 @@
                     >
                       <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
                     </svg>
-                    move down
+                    down
                   </button>
                   <button
                     class="swap-workout-session-exercise-btn hidden cursor-pointer flex items-center justify-center gap-2 rounded-lg border border-jim-accent/40 min-h-0 px-3 py-1.5 text-sm text-jim-accent/80 transition-colors duration-150 hover:border-jim-accent/60 hover:text-jim-accent active:bg-jim-accent/20"


### PR DESCRIPTION
Changes the button texts 'move up' and 'move down' to 'up' and 'down' respectively in the gymtime exercise card for a better user experience.

---
*PR created automatically by Jules for task [13916581393883007693](https://jules.google.com/task/13916581393883007693) started by @nop33*