### PR TITLE
feat: add estimated 1RM and total volume to exercise chart

### DIFF
--- a/gymtime/index.html
+++ b/gymtime/index.html
@@ -387,8 +387,7 @@
         </button>
       </header>
       <div class="h-[calc(100%-4rem)] w-full flex flex-col">
-        <div class="text-sm text-neutral-400 mb-4">Average weight per session</div>
-        <div class="grow w-full relative">
+        <div class="grow w-full relative mt-4">
           <canvas id="exercise-history-chart"></canvas>
         </div>
       </div>

--- a/gymtime/index.html
+++ b/gymtime/index.html
@@ -363,31 +363,31 @@
 
     <dialog
       id="exercise-history-dialog"
-      class="w-[95vw] h-[95vh] sm:w-[80vw] sm:h-[80vh] max-w-none max-h-none m-auto overflow-hidden rounded-xl force-landscape-in-portrait"
+      class="w-[95dvw] h-[95dvh] sm:w-[80dvw] sm:h-[80dvh] max-w-none max-h-none m-auto overflow-hidden rounded-xl force-landscape-in-portrait"
     >
-      <header class="flex justify-between items-center">
-        <h2 class="text-xl font-bold exercise-history-title flex items-center gap-2">
-          <span>Exercise History</span>
-        </h2>
-        <button
-          type="button"
-          class="close-dialog-btn border border-neutral-600/50 p-2 rounded-xl text-neutral-400 hover:text-white hover:bg-neutral-700 transition-colors duration-200"
-          aria-label="Close dialog"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke-width="1.5"
-            stroke="currentColor"
-            class="size-6"
+      <div class="h-full w-full flex flex-col">
+        <header class="flex justify-between items-center shrink-0">
+          <h2 class="text-xl font-bold exercise-history-title flex items-center gap-2">
+            <span>Exercise History</span>
+          </h2>
+          <button
+            type="button"
+            class="close-dialog-btn border border-neutral-600/50 p-2 rounded-xl text-neutral-400 hover:text-white hover:bg-neutral-700 transition-colors duration-200"
+            aria-label="Close dialog"
           >
-            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
-          </svg>
-        </button>
-      </header>
-      <div class="h-[calc(100%-4rem)] w-full flex flex-col">
-        <div class="grow w-full relative mt-4">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke-width="1.5"
+              stroke="currentColor"
+              class="size-6"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </header>
+        <div class="flex-1 min-h-0 w-full relative mt-4">
           <canvas id="exercise-history-chart"></canvas>
         </div>
       </div>

--- a/gymtime/index.html
+++ b/gymtime/index.html
@@ -363,7 +363,7 @@
 
     <dialog
       id="exercise-history-dialog"
-      class="w-[95vw] h-[95vh] sm:w-[80vw] sm:h-[80vh] max-w-none max-h-none m-auto overflow-hidden rounded-xl"
+      class="w-[95vw] h-[95vh] sm:w-[80vw] sm:h-[80vh] max-w-none max-h-none m-auto overflow-hidden rounded-xl force-landscape-in-portrait"
     >
       <header class="flex justify-between items-center">
         <h2 class="text-xl font-bold exercise-history-title flex items-center gap-2">

--- a/src/pages/gymtime/ExerciseHistoryChart.ts
+++ b/src/pages/gymtime/ExerciseHistoryChart.ts
@@ -54,22 +54,30 @@ class ExerciseHistoryChart {
     relevantSessions.sort((a, b) => new Date(a.session.date).getTime() - new Date(b.session.date).getTime())
 
     const labels: string[] = []
-    const dataPoints: number[] = []
+    const avgWeightData: number[] = []
+    const est1rmData: number[] = []
+    const totalVolumeData: number[] = []
 
     for (const { session, exerciseExec } of relevantSessions) {
       let totalWeight = 0
+      let total1rm = 0
+      let totalVolume = 0
       let validSetsCount = 0
 
       for (const set of exerciseExec.sets) {
         if (set.reps > 0) {
           totalWeight += set.weight
+          total1rm += set.weight * (1 + set.reps / 30)
+          totalVolume += set.weight * set.reps
           validSetsCount++
         }
       }
 
       if (validSetsCount > 0) {
         labels.push(new Date(session.date).toLocaleDateString(undefined, { month: 'short', day: 'numeric' }))
-        dataPoints.push(totalWeight / validSetsCount)
+        avgWeightData.push(totalWeight / validSetsCount)
+        est1rmData.push(total1rm / validSetsCount)
+        totalVolumeData.push(totalVolume)
       }
     }
 
@@ -83,6 +91,8 @@ class ExerciseHistoryChart {
     const textColor = isDarkMode ? '#e5e5e5' : '#262626'
     const gridColor = isDarkMode ? '#404040' : '#d4d4d4'
     const accentColor = '#3b82f6' // jim-accent roughly
+    const est1rmColor = '#10b981' // emerald-500
+    const volumeColor = '#8b5cf6' // violet-500
 
     this.chartInstance = new Chart(this.canvas, {
       type: 'line',
@@ -91,7 +101,7 @@ class ExerciseHistoryChart {
         datasets: [
           {
             label: 'Average Weight',
-            data: dataPoints,
+            data: avgWeightData,
             borderColor: accentColor,
             backgroundColor: accentColor + '33', // 20% opacity
             borderWidth: 2,
@@ -100,7 +110,36 @@ class ExerciseHistoryChart {
             pointBorderWidth: 2,
             pointRadius: 4,
             fill: true,
-            tension: 0.3
+            tension: 0.3,
+            yAxisID: 'y'
+          },
+          {
+            label: 'Estimated 1RM (Avg)',
+            data: est1rmData,
+            borderColor: est1rmColor,
+            backgroundColor: est1rmColor + '33',
+            borderWidth: 2,
+            pointBackgroundColor: est1rmColor,
+            pointBorderColor: isDarkMode ? '#171717' : '#ffffff',
+            pointBorderWidth: 2,
+            pointRadius: 4,
+            fill: true,
+            tension: 0.3,
+            yAxisID: 'y'
+          },
+          {
+            label: 'Total Volume',
+            data: totalVolumeData,
+            borderColor: volumeColor,
+            backgroundColor: volumeColor + '33',
+            borderWidth: 2,
+            pointBackgroundColor: volumeColor,
+            pointBorderColor: isDarkMode ? '#171717' : '#ffffff',
+            pointBorderWidth: 2,
+            pointRadius: 4,
+            fill: true,
+            tension: 0.3,
+            yAxisID: 'y1'
           }
         ]
       },
@@ -109,13 +148,16 @@ class ExerciseHistoryChart {
         maintainAspectRatio: false,
         plugins: {
           legend: {
-            display: false
+            display: true,
+            labels: {
+              color: textColor
+            }
           },
           tooltip: {
             callbacks: {
               label: (context) => {
                 const value = context.parsed.y !== null ? context.parsed.y.toFixed(1) : ''
-                return `${value} kg`
+                return `${context.dataset.label}: ${value}`
               }
             }
           }
@@ -133,6 +175,14 @@ class ExerciseHistoryChart {
             }
           },
           y: {
+            type: 'linear',
+            display: true,
+            position: 'left',
+            title: {
+              display: true,
+              text: 'Weight',
+              color: textColor
+            },
             ticks: {
               color: textColor
             },
@@ -140,6 +190,23 @@ class ExerciseHistoryChart {
               color: gridColor
             },
             beginAtZero: false
+          },
+          y1: {
+            type: 'linear',
+            display: true,
+            position: 'right',
+            title: {
+              display: true,
+              text: 'Volume',
+              color: textColor
+            },
+            ticks: {
+              color: textColor
+            },
+            grid: {
+              drawOnChartArea: false // only want the grid lines for one axis to show up
+            },
+            beginAtZero: true
           }
         }
       }

--- a/src/style.css
+++ b/src/style.css
@@ -322,8 +322,8 @@
     transform: rotate(90deg);
     transform-origin: center center;
     /* We effectively swap width and height */
-    width: 95vh !important;
-    height: 95vw !important;
+    width: 95dvh !important;
+    height: 95dvw !important;
     /* Adjust margin/position to center it after rotation */
     margin: 0 !important;
     position: absolute !important;

--- a/src/style.css
+++ b/src/style.css
@@ -315,3 +315,20 @@
     bottom: -12px;
   }
 }
+
+/* Force landscape via CSS rotation when in portrait orientation */
+@media (orientation: portrait) {
+  .force-landscape-in-portrait {
+    transform: rotate(90deg);
+    transform-origin: center center;
+    /* We effectively swap width and height */
+    width: 95vh !important;
+    height: 95vw !important;
+    /* Adjust margin/position to center it after rotation */
+    margin: 0 !important;
+    position: absolute !important;
+    top: 50% !important;
+    left: 50% !important;
+    translate: -50% -50% !important;
+  }
+}


### PR DESCRIPTION
This pull request updates the exercise history chart to track two additional key metrics: **Estimated 1RM** and **Total Volume**.

**Changes:**
- **Estimated 1RM:** Calculated per set using the Epley formula (`Weight × (1 + Reps / 30)`) and averaged for the session to provide a truer picture of strength progression beyond just average weight.
- **Total Volume:** Calculated as the sum of `Weight × Reps` across all sets in a session to track endurance and workload.
- **Chart Layout:** 
  - All three metrics are now plotted with distinct colors.
  - A legend has been enabled so users can distinguish the lines.
  - A secondary Y-axis was added on the right side specifically for Volume. Since Volume numbers are typically much higher (e.g., 1000+ lbs), plotting them on the same axis as Weight (~100-200 lbs) would have flattened the weight progression lines.
- **UI:** The hardcoded "Average weight per session" subtitle was removed from the HTML, as the legend now handles data labeling.

---
*PR created automatically by Jules for task [14178629551921440282](https://jules.google.com/task/14178629551921440282) started by @nop33*