### PR TITLE
Add minimize capability to break countdown timer

### DIFF
--- a/gymtime/index.html
+++ b/gymtime/index.html
@@ -295,20 +295,20 @@
 
     <dialog id="break-countdown-dialog">
       <div class="h-full w-full flex flex-col items-center justify-between">
-        <p class="text-4xl font-bold"><span id="sets-done" class="text-jim-accent"></span> done.</p>
-        <h2 id="countdown" class="text-9xl font-bold font-mono">
+        <p class="text-4xl font-bold hide-when-minimized"><span id="sets-done" class="text-jim-accent"></span> done.</p>
+        <h2 id="countdown" class="text-9xl font-bold font-mono transition-all duration-300">
           <!-- -->
         </h2>
-        <div class="w-full flex flex-col gap-4 items-center">
+        <div class="w-full flex flex-col gap-4 items-center hide-when-minimized">
           <p id="next-exercise-message" class="text-xl font-bold">
             Coming up: <span id="next-exercise-name" class="text-jim-accent"></span>
           </p>
-          <div class="flex items-center gap-2 self-end">
+          <div class="w-full flex items-center justify-between">
             <button
-              id="view-history-break"
+              id="minimize-break"
               type="button"
-              aria-label="View exercise history"
               class="flex items-center justify-center rounded-xl border border-neutral-600/50 p-3 transition-colors hover:bg-neutral-700 hover:text-white"
+              aria-label="Minimize"
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -318,14 +318,33 @@
                 stroke="currentColor"
                 class="size-5"
               >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z"
-                />
+                <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 15.75l7.5-7.5 7.5 7.5" />
               </svg>
             </button>
-            <button id="skip-break" class="btn-secondary">Skip</button>
+            <div class="flex items-center gap-2">
+              <button
+                id="view-history-break"
+                type="button"
+                aria-label="View exercise history"
+                class="flex items-center justify-center rounded-xl border border-neutral-600/50 p-3 transition-colors hover:bg-neutral-700 hover:text-white"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke-width="1.5"
+                  stroke="currentColor"
+                  class="size-5"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z"
+                  />
+                </svg>
+              </button>
+              <button id="skip-break" class="btn-secondary">Skip</button>
+            </div>
           </div>
         </div>
       </div>

--- a/src/pages/gymtime/BreakTimerDialog.ts
+++ b/src/pages/gymtime/BreakTimerDialog.ts
@@ -4,6 +4,7 @@ import { playDingSound } from './sound'
 
 class BreakTimerDialog {
   private static dialog = document.querySelector('#break-countdown-dialog') as HTMLDialogElement
+  private static minimizeButton = this.dialog.querySelector('#minimize-break') as HTMLButtonElement
   private static countdown = this.dialog.querySelector('#countdown') as HTMLHeadingElement
   private static countdownInterval: ReturnType<typeof setInterval> | null = null
   private static skipBreakButton = this.dialog.querySelector('#skip-break') as HTMLButtonElement
@@ -15,13 +16,39 @@ class BreakTimerDialog {
   private static hasPlayedSound = false
   private static autoCloseTimeout: ReturnType<typeof setTimeout> | null = null
   private static currentExercise: Exercise | null = null
+  private static isMinimized = false
 
   static init() {
     this.skipBreakButton.addEventListener('click', () => this.closeDialog())
+    this.minimizeButton.addEventListener('click', (e) => {
+      e.stopPropagation()
+      this.minimizeDialog()
+    })
+    this.dialog.addEventListener('click', () => {
+      if (this.isMinimized) {
+        this.maximizeDialog()
+      }
+    })
     this.viewHistoryButton.addEventListener('click', () => {
       if (this.currentExercise) ExerciseHistoryChart.openDialog(this.currentExercise)
     })
     document.addEventListener('visibilitychange', () => this.handleVisibilityChange())
+  }
+
+  private static minimizeDialog() {
+    this.isMinimized = true
+    this.dialog.close()
+    this.dialog.classList.remove('dialog-full-screen')
+    this.dialog.classList.add('dialog-minimized')
+    this.dialog.show()
+  }
+
+  private static maximizeDialog() {
+    this.isMinimized = false
+    this.dialog.close()
+    this.dialog.classList.remove('dialog-minimized')
+    this.dialog.classList.add('dialog-full-screen')
+    this.dialog.showModal()
   }
 
   private static handleVisibilityChange() {
@@ -98,7 +125,12 @@ class BreakTimerDialog {
   }
 
   private static openDialog() {
+    this.isMinimized = false
+    this.dialog.classList.remove('dialog-minimized')
     this.dialog.classList.add('dialog-full-screen')
+    if (this.dialog.open) {
+      this.dialog.close()
+    }
     this.dialog.showModal()
   }
 
@@ -114,7 +146,9 @@ class BreakTimerDialog {
     this.targetTime = null
     this.hasPlayedSound = false
     this.currentExercise = null
+    this.isMinimized = false
     this.dialog.classList.remove('dialog-full-screen')
+    this.dialog.classList.remove('dialog-minimized')
     this.dialog.close()
   }
 }

--- a/src/style.css
+++ b/src/style.css
@@ -204,6 +204,23 @@
     @apply h-full w-full;
   }
 
+  .dialog-minimized {
+    @apply fixed top-0 z-50 w-full max-w-full rounded-none rounded-b-2xl p-4 cursor-pointer m-0 border-t-0 border-x-0 border-b border-neutral-700/50 shadow-lg flex items-center justify-center;
+  }
+
+  .dialog-minimized::backdrop {
+    display: none;
+  }
+
+  .dialog-minimized .hide-when-minimized {
+    display: none !important;
+  }
+
+  .dialog-minimized #countdown {
+    font-size: 2.25rem !important;
+    line-height: 2.5rem !important;
+  }
+
   dialog > header {
     @apply mb-6 flex items-center justify-between;
   }


### PR DESCRIPTION
This PR adds a button to the break countdown dialog allowing it to be minimized into a small fixed bar at the top of the screen.

When minimized, the user can still see the timer but can now interact with the rest of the application (e.g. view notes, edit sets, scroll the workout). Clicking the minimized bar maximizes it back to full screen. It intelligently toggles between the `<dialog>` modal and non-modal states.

Visual verification passes and tests are green.

---
*PR created automatically by Jules for task [3136185238777800089](https://jules.google.com/task/3136185238777800089) started by @nop33*