### PR TITLE
feat: Add configurable break time to workout settings

### DIFF
--- a/settings/index.html
+++ b/settings/index.html
@@ -29,6 +29,30 @@
       <div class="app-page-content">
         <div class="flex flex-col gap-6">
           <div class="card card-hover">
+            <details id="workout-settings-details">
+              <summary class="flex items-center justify-between">
+                <span class="text-xl font-bold text-jim-neutral">⏱️ Workout Settings</span>
+              </summary>
+              <div class="flex flex-col gap-4 mt-4">
+                <div>
+                  <h3 class="text-lg font-bold mb-2">Break Time</h3>
+                  <div class="flex gap-4 items-center">
+                    <label class="text-jim-neutral-secondary flex flex-col flex-1">
+                      Minutes
+                      <input type="number" id="break-minutes" min="0" max="59" class="mt-2" />
+                    </label>
+                    <label class="text-jim-neutral-secondary flex flex-col flex-1">
+                      Seconds
+                      <input type="number" id="break-seconds" min="0" max="59" class="mt-2" />
+                    </label>
+                  </div>
+                  <button id="save-break-time" class="btn-primary mt-4 w-full">Save Break Time</button>
+                </div>
+              </div>
+            </details>
+          </div>
+
+          <div class="card card-hover">
             <details id="cloud-backup-details">
               <summary class="flex items-center justify-between">
                 <span class="text-xl font-bold text-jim-neutral">☁️ Cloud Backup</span>

--- a/src/pages/gymtime/ExerciseCard.ts
+++ b/src/pages/gymtime/ExerciseCard.ts
@@ -4,6 +4,7 @@ import type { Exercise } from '../../db/stores/exercisesStore'
 import { workoutSessionsStore, type ExerciseSetExecution } from '../../db/stores/workoutSessionsStore'
 import { throwConfetti } from '../../features/confetti'
 import GymtimeSessionState from '../../state/GymtimeSessionState'
+import { getBreakTimeSeconds } from '../../settings'
 import { nodeFromTemplate, setTextContent } from '../../utils'
 import { animateDetails, type AnimateDetailsHandle } from './animateDetails'
 import BreakTimerDialog from './BreakTimerDialog'
@@ -349,9 +350,11 @@ class ExerciseCard {
             }
           }
 
+          const breakTimeSeconds = getBreakTimeSeconds()
+
           BreakTimerDialog.startTimer({
-            minutes: 2,
-            seconds: 30,
+            minutes: Math.floor(breakTimeSeconds / 60),
+            seconds: breakTimeSeconds % 60,
             setsDone: setIndex + 1,
             setsTotal: this.exercise.sets,
             nextExercise: nextExercise?.name,

--- a/src/pages/settings/index.ts
+++ b/src/pages/settings/index.ts
@@ -3,9 +3,34 @@ import { exportIndexedDbToJson } from '../../db/export'
 import { importIndexedDbFromJson } from '../../db/import'
 import { storage } from '../../db/storage'
 import Toasts from '../../features/toasts'
+import { getBreakTimeSeconds, storeBreakTimeSeconds } from '../../settings'
 import CloudBackup from './CloudBackup'
 
 CloudBackup.init()
+
+const breakMinutesInput = document.querySelector('#break-minutes') as HTMLInputElement
+const breakSecondsInput = document.querySelector('#break-seconds') as HTMLInputElement
+const saveBreakTimeBtn = document.querySelector('#save-break-time') as HTMLButtonElement
+
+if (breakMinutesInput && breakSecondsInput && saveBreakTimeBtn) {
+  const currentBreakTime = getBreakTimeSeconds()
+  breakMinutesInput.value = Math.floor(currentBreakTime / 60).toString()
+  breakSecondsInput.value = (currentBreakTime % 60).toString()
+
+  saveBreakTimeBtn.addEventListener('click', () => {
+    const minutes = parseInt(breakMinutesInput.value, 10) || 0
+    const seconds = parseInt(breakSecondsInput.value, 10) || 0
+    const totalSeconds = minutes * 60 + seconds
+
+    if (totalSeconds < 0) {
+      Toasts.show({ message: 'Break time cannot be negative.', type: 'error' })
+      return
+    }
+
+    storeBreakTimeSeconds(totalSeconds)
+    Toasts.show({ message: 'Break time saved!', type: 'success' })
+  })
+}
 
 const exportJsonBtn = document.querySelector('#export-json') as HTMLButtonElement
 exportJsonBtn.addEventListener('click', exportIndexedDbToJson)

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -32,3 +32,18 @@ export const getEffectiveWorkoutsPerWeek = (programCount: number): number => {
   const settings = getWorkoutModeSettings()
   return settings.mode === 'rotation' ? programCount : settings.weeklyGoal
 }
+
+const BREAK_TIME_STORAGE_KEY = 'jimbro.breakTime'
+const DEFAULT_BREAK_TIME_SECONDS = 150
+
+export const getBreakTimeSeconds = (): number => {
+  const raw = localStorage.getItem(BREAK_TIME_STORAGE_KEY)
+  if (!raw) return DEFAULT_BREAK_TIME_SECONDS
+
+  const parsed = parseInt(raw, 10)
+  return isNaN(parsed) ? DEFAULT_BREAK_TIME_SECONDS : parsed
+}
+
+export const storeBreakTimeSeconds = (seconds: number) => {
+  localStorage.setItem(BREAK_TIME_STORAGE_KEY, seconds.toString())
+}


### PR DESCRIPTION
This PR introduces a user-configurable break time setting, allowing users to customize the duration of the break timer that appears between workout sets.

**Key Changes:**
* Added a new "Workout Settings" section in `settings/index.html` featuring inputs for minutes and seconds.
* Updated `src/settings.ts` with functions to get and store the break time in `localStorage`.
* Hooked up the UI in `src/pages/settings/index.ts` to persist the new configuration values, with safeguards against negative numbers.
* Updated `src/pages/gymtime/ExerciseCard.ts` to utilize the user's preferred break time when initializing `BreakTimerDialog.startTimer()`.
* Performed visual verification using Playwright to confirm the feature works end-to-end.

---
*PR created automatically by Jules for task [9000369945979713319](https://jules.google.com/task/9000369945979713319) started by @nop33*