### PR TITLE
feat: Add Rehab exercise type

### DIFF
--- a/exercises/index.html
+++ b/exercises/index.html
@@ -117,6 +117,10 @@
             <!-- Muscle groups will be rendered here -->
           </select>
         </div>
+        <div class="flex items-center gap-2">
+          <input type="checkbox" id="exercise-is-rehab" name="isRehab" class="size-4" />
+          <label for="exercise-is-rehab" class="cursor-pointer select-none">Is Rehab Exercise</label>
+        </div>
         <div>
           <label for="exercise-sets">Default sets</label>
           <input type="number" id="exercise-sets" name="sets" min="1" required />

--- a/gymtime/index.html
+++ b/gymtime/index.html
@@ -134,9 +134,12 @@
                     <!-- -->
                   </h3>
 
-                  <span class="exercise-muscle badge ml-2">
-                    <!-- -->
-                  </span>
+                  <div class="flex flex-col gap-1 items-end ml-2">
+                    <span class="exercise-muscle badge">
+                      <!-- -->
+                    </span>
+                    <span class="exercise-rehab badge bg-jim-accent text-neutral-900 hidden"> Rehab </span>
+                  </div>
                 </div>
               </div>
             </header>
@@ -499,9 +502,12 @@
               <h3 class="exercise-name card-title">
                 <!-- -->
               </h3>
-              <span class="exercise-muscle badge">
-                <!-- -->
-              </span>
+              <div class="flex flex-col gap-1 items-end">
+                <span class="exercise-muscle badge">
+                  <!-- -->
+                </span>
+                <span class="exercise-rehab badge bg-jim-accent text-neutral-900 hidden"> Rehab </span>
+              </div>
             </header>
             <p class="text-sm text-neutral-400 font-medium">
               <span class="exercise-sets"></span> sets × <span class="exercise-reps"></span> reps

--- a/src/db/stores/exercisesStore.ts
+++ b/src/db/stores/exercisesStore.ts
@@ -8,6 +8,7 @@ export interface Exercise {
   sets: number
   reps: number
   isDeleted?: boolean
+  isRehab?: boolean
 }
 
 export type NewExercise = Omit<Exercise, 'id'>

--- a/src/pages/exercises/ExerciseComponent.ts
+++ b/src/pages/exercises/ExerciseComponent.ts
@@ -16,6 +16,11 @@ class ExerciseComponent {
     setTextContent('.exercise-sets', this.exercise.sets.toString(), exerciseItem)
     setTextContent('.exercise-reps', this.exercise.reps.toString(), exerciseItem)
 
+    const rehabBadge = exerciseItem.querySelector('.exercise-rehab') as HTMLSpanElement
+    if (this.exercise.isRehab && rehabBadge) {
+      rehabBadge.classList.remove('hidden')
+    }
+
     exerciseItem.querySelector('div')?.addEventListener('click', () => {
       window.dispatchEvent(new CustomEvent('exercise-clicked', { detail: { exercise: this.exercise } }))
     })

--- a/src/pages/exercises/ExerciseDialog.ts
+++ b/src/pages/exercises/ExerciseDialog.ts
@@ -11,6 +11,7 @@ class ExerciseDialog {
   private static exerciseIdInput = document.querySelector('#exercise-id') as HTMLInputElement
   private static exerciseNameInput = document.querySelector('#exercise-name') as HTMLInputElement
   private static exerciseMuscleSelect = document.querySelector('#exercise-muscle') as HTMLSelectElement
+  private static exerciseIsRehabCheckbox = document.querySelector('#exercise-is-rehab') as HTMLInputElement
   private static exerciseSetsInput = document.querySelector('#exercise-sets') as HTMLInputElement
   private static exerciseRepsInput = document.querySelector('#exercise-reps') as HTMLInputElement
   private static dialogTitle = document.querySelector('#dialog-title') as HTMLHeadingElement
@@ -57,14 +58,15 @@ class ExerciseDialog {
       const id = this.exerciseIdInput.value
       const name = formData.get('name') as string
       const muscle = formData.get('muscle') as Exercise['muscle']
+      const isRehab = formData.get('isRehab') === 'on'
       const sets = parseInt(formData.get('sets') as string)
       const reps = parseInt(formData.get('reps') as string)
 
       try {
         if (id) {
-          await ExercisesState.updateExercise({ id, name, muscle, sets, reps })
+          await ExercisesState.updateExercise({ id, name, muscle, sets, reps, isRehab })
         } else {
-          await ExercisesState.createExercise({ name, muscle, sets, reps })
+          await ExercisesState.createExercise({ name, muscle, sets, reps, isRehab })
         }
 
         this.closeDialog()
@@ -83,12 +85,14 @@ class ExerciseDialog {
       this.deleteExerciseBtn.classList.remove('hidden')
       this.exerciseNameInput.value = exercise.name
       this.exerciseMuscleSelect.value = exercise.muscle
+      this.exerciseIsRehabCheckbox.checked = !!exercise.isRehab
       this.exerciseSetsInput.value = exercise.sets.toString()
       this.exerciseRepsInput.value = exercise.reps.toString()
     } else {
       this.dialogTitle.textContent = 'New Exercise'
       this.exerciseForm.reset()
       this.exerciseIdInput.value = ''
+      this.exerciseIsRehabCheckbox.checked = false
       this.deleteExerciseBtn.classList.add('hidden')
     }
   }

--- a/src/pages/gymtime/EditSetDialog.ts
+++ b/src/pages/gymtime/EditSetDialog.ts
@@ -8,6 +8,7 @@ interface EditSetData {
   set: ExerciseSetExecution
   exerciseId: Exercise['id']
   index: number
+  isRehab?: boolean
 }
 
 class EditSetDialog {
@@ -43,7 +44,7 @@ class EditSetDialog {
     const reps = formData.get('set-reps') as string
     const weight = formData.get('set-weight') as string
 
-    if (weight === '0' || reps === '0') {
+    if (reps === '0' || (weight === '0' && !this.editedSetData.isRehab)) {
       if (!confirm(`Are you sure you want to submit a set with 0 ${weight === '0' ? 'weight' : 'reps'}?`)) return
     }
 

--- a/src/pages/gymtime/ExerciseCard.ts
+++ b/src/pages/gymtime/ExerciseCard.ts
@@ -157,6 +157,11 @@ class ExerciseCard {
     setTextContent('.exercise-name', this.exercise.name, template)
     setTextContent('.exercise-muscle', this.exercise.muscle, template)
 
+    const rehabBadge = template.querySelector('.exercise-rehab') as HTMLSpanElement
+    if (this.exercise.isRehab && rehabBadge) {
+      rehabBadge.classList.remove('hidden')
+    }
+
     const session = GymtimeSessionState.session
     const existingExercise = session?.exercises.find(({ exerciseId }) => exerciseId === this.exercise.id)
 
@@ -242,7 +247,8 @@ class ExerciseCard {
           weight: parseFloat(div.dataset.weight!)
         },
         exerciseId: this.exercise.id,
-        index
+        index,
+        isRehab: this.exercise.isRehab
       })
     })
 
@@ -303,7 +309,7 @@ class ExerciseCard {
       const reps = formData.get('set-reps') as string
       const weight = formData.get('set-weight') as string
 
-      if (weight === '0' || reps === '0') {
+      if (reps === '0' || (weight === '0' && !this.exercise.isRehab)) {
         if (!confirm(`Are you sure you want to submit a set with 0 ${weight === '0' ? 'weight' : 'reps'}?`)) return
       }
 
@@ -371,14 +377,16 @@ class ExerciseCard {
 
           const breakTimeSeconds = getBreakTimeSeconds()
 
-          BreakTimerDialog.startTimer({
-            minutes: Math.floor(breakTimeSeconds / 60),
-            seconds: breakTimeSeconds % 60,
-            setsDone: setIndex + 1,
-            setsTotal: this.exercise.sets,
-            nextExercise: nextExercise?.name,
-            currentExercise: this.exercise
-          })
+          if (!this.exercise.isRehab) {
+            BreakTimerDialog.startTimer({
+              minutes: Math.floor(breakTimeSeconds / 60),
+              seconds: breakTimeSeconds % 60,
+              setsDone: setIndex + 1,
+              setsTotal: this.exercise.sets,
+              nextExercise: nextExercise?.name,
+              currentExercise: this.exercise
+            })
+          }
         }
       }
     })


### PR DESCRIPTION
Adds a new boolean flag `isRehab` to the Exercise schema. This new exercise type allows users to specify that an exercise is meant for rehabilitation.

- Displays a new "Rehab" badge in addition to the muscle group badge on exercise cards.
- Skips the 0kg warning modal for rehab exercises when saving sets with no weight.
- Disables the break timer start for rehab exercises, allowing users to move on instantly.

---
*PR created automatically by Jules for task [13705800866312909923](https://jules.google.com/task/13705800866312909923) started by @nop33*