### PR TITLE
Move "Add set" button and style with dashed border

### DIFF
--- a/gymtime/index.html
+++ b/gymtime/index.html
@@ -219,6 +219,22 @@
                 <div class="completed-sets flex flex-col gap-2">
                   <!-- Completed sets will be rendered here -->
                 </div>
+                <button
+                  type="button"
+                  class="add-extra-set-btn w-full py-2 mt-2 text-sm flex items-center justify-center gap-2 border border-dashed border-neutral-600/50 text-neutral-400 rounded-xl hover:bg-neutral-700/50 hover:text-white transition-colors duration-200"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke-width="1.5"
+                    stroke="currentColor"
+                    class="size-5"
+                  >
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+                  </svg>
+                  Add set
+                </button>
                 <div class="next-set mt-3">
                   <form class="next-set-form flex flex-col gap-4">
                     <div class="grid grid-cols-2 gap-3">
@@ -254,22 +270,6 @@
                     </div>
                     <button type="submit" class="btn-primary text-white w-full py-5 text-lg">Finished set</button>
                   </form>
-                  <button
-                    type="button"
-                    class="add-extra-set-btn btn-secondary w-full py-2 mt-2 text-sm flex items-center justify-center gap-2"
-                  >
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke-width="1.5"
-                      stroke="currentColor"
-                      class="size-5"
-                    >
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
-                    </svg>
-                    Add set
-                  </button>
                 </div>
                 <div class="flex gap-2 w-full mt-4">
                   <button


### PR DESCRIPTION
Moved the "Add set" button to be immediately below the completed sets section and restyled it with a dashed border per user request. Also updated the Playwright E2E tests to handle the new DOM layout where the `.next-set-form` can be hidden or located slightly differently when searching within details.

---
*PR created automatically by Jules for task [14465354662082848977](https://jules.google.com/task/14465354662082848977) started by @nop33*